### PR TITLE
[Issue #16] GitHub Actions OIDC認証の実装

### DIFF
--- a/.github/workflows/build-push-gar.yaml
+++ b/.github/workflows/build-push-gar.yaml
@@ -1,0 +1,97 @@
+name: Build and Push to GAR
+
+on:
+  workflow_dispatch:
+    inputs:
+      module:
+        description: 'Module to build (v1-cloud-run or v2-firestore)'
+        required: true
+        type: choice
+        options:
+          - v1-cloud-run
+          - v2-firestore
+  push:
+    branches:
+      - main
+    paths:
+      - 'v1-cloud-run/**'
+      - 'v2-firestore/**'
+      - '.github/workflows/build-push-gar.yaml'
+
+env:
+  # プロジェクトIDとリージョンは GitHub Secrets で設定
+  # PROJECT_ID: your-gcp-project-id
+  # REGION: asia-northeast1
+  GAR_REPOSITORY: samples
+
+permissions:
+  contents: read
+  id-token: write # OIDC トークンの取得に必要
+
+jobs:
+  build-push:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        module: ${{ fromJson(github.event_name == 'workflow_dispatch' && format('["{0}"]', inputs.module) || '["v1-cloud-run", "v2-firestore"]') }}
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # OIDC による GCP 認証
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
+          service_account: ${{ secrets.WIF_SERVICE_ACCOUNT }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Configure Docker auth for GAR
+        run: |
+          gcloud auth configure-docker ${{ secrets.REGION }}-docker.pkg.dev
+
+      - name: Determine image metadata
+        id: meta
+        run: |
+          MODULE="${{ matrix.module }}"
+          SERVICE_NAME=${MODULE/v[0-9]-/}  # v1-cloud-run -> cloud-run
+          IMAGE_NAME="${{ secrets.REGION }}-docker.pkg.dev/${{ secrets.PROJECT_ID }}/${{ env.GAR_REPOSITORY }}/$SERVICE_NAME"
+          SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
+          
+          if [[ "${{ github.event_name }}" == "push" ]]; then
+            TAGS="${IMAGE_NAME}:${SHORT_SHA},${IMAGE_NAME}:latest"
+          else
+            TAGS="${IMAGE_NAME}:manual-${SHORT_SHA}"
+          fi
+          
+          echo "tags=$TAGS" >> $GITHUB_OUTPUT
+          echo "service_name=$SERVICE_NAME" >> $GITHUB_OUTPUT
+          echo "Building image: $IMAGE_NAME"
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./${{ matrix.module }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64
+          provenance: false # マルチプラットフォームビルドで必要
+
+      - name: Output image info
+        run: |
+          echo "✅ Successfully pushed Docker image:"
+          echo "   Tags: ${{ steps.meta.outputs.tags }}"
+          echo ""
+          echo "📝 To deploy to Cloud Run:"
+          echo "   gcloud run deploy ${{ steps.meta.outputs.service_name }} \\"
+          echo "     --image $(echo '${{ steps.meta.outputs.tags }}' | cut -d',' -f1) \\"
+          echo "     --region ${{ secrets.REGION }} \\"
+          echo "     --platform managed"

--- a/.github/workflows/deploy-cloudrun.yaml
+++ b/.github/workflows/deploy-cloudrun.yaml
@@ -1,0 +1,114 @@
+name: Deploy to Cloud Run
+
+on:
+  workflow_dispatch:
+    inputs:
+      module:
+        description: 'Module to deploy (v1-cloud-run or v2-firestore)'
+        required: true
+        type: choice
+        options:
+          - v1-cloud-run
+          - v2-firestore
+      image_tag:
+        description: 'Docker image tag to deploy (e.g., latest, abc1234)'
+        required: false
+        default: 'latest'
+      allow_unauthenticated:
+        description: 'Allow unauthenticated access'
+        required: true
+        type: boolean
+        default: true
+
+env:
+  GAR_REPOSITORY: samples
+
+permissions:
+  contents: read
+  id-token: write # OIDC トークンの取得に必要
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # OIDC による GCP 認証
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
+          service_account: ${{ secrets.WIF_SERVICE_ACCOUNT }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Prepare deployment config
+        id: config
+        run: |
+          MODULE="${{ inputs.module }}"
+          SERVICE_NAME=${MODULE/v[0-9]-/}  # v1-cloud-run -> cloud-run
+          IMAGE_NAME="${{ secrets.REGION }}-docker.pkg.dev/${{ secrets.PROJECT_ID }}/${{ env.GAR_REPOSITORY }}/$SERVICE_NAME:${{ inputs.image_tag }}"
+          
+          echo "service_name=$SERVICE_NAME" >> $GITHUB_OUTPUT
+          echo "image=$IMAGE_NAME" >> $GITHUB_OUTPUT
+          
+          # 環境変数の設定
+          if [[ "$MODULE" == "v1-cloud-run" ]]; then
+            echo "env_vars=TARGET=Production" >> $GITHUB_OUTPUT
+          elif [[ "$MODULE" == "v2-firestore" ]]; then
+            echo "env_vars=PROJECT_ID=${{ secrets.PROJECT_ID }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Deploy to Cloud Run
+        run: |
+          DEPLOY_CMD="gcloud run deploy ${{ steps.config.outputs.service_name }} \
+            --image ${{ steps.config.outputs.image }} \
+            --region ${{ secrets.REGION }} \
+            --platform managed \
+            --port 8080 \
+            --memory 512Mi \
+            --cpu 1 \
+            --timeout 300 \
+            --concurrency 80 \
+            --min-instances 0 \
+            --max-instances 100"
+          
+          # 環境変数の設定
+          if [[ -n "${{ steps.config.outputs.env_vars }}" ]]; then
+            DEPLOY_CMD="$DEPLOY_CMD --set-env-vars ${{ steps.config.outputs.env_vars }}"
+          fi
+          
+          # 認証設定
+          if [[ "${{ inputs.allow_unauthenticated }}" == "true" ]]; then
+            DEPLOY_CMD="$DEPLOY_CMD --allow-unauthenticated"
+          else
+            DEPLOY_CMD="$DEPLOY_CMD --no-allow-unauthenticated"
+          fi
+          
+          echo "🚀 Deploying with command:"
+          echo "$DEPLOY_CMD"
+          
+          eval $DEPLOY_CMD
+
+      - name: Get service URL
+        run: |
+          SERVICE_URL=$(gcloud run services describe ${{ steps.config.outputs.service_name }} \
+            --region ${{ secrets.REGION }} \
+            --format 'value(status.url)')
+          
+          echo "✅ Deployment successful!"
+          echo "🔗 Service URL: $SERVICE_URL"
+          echo ""
+          echo "📝 Test the service:"
+          echo "   curl $SERVICE_URL"
+          if [[ "${{ inputs.module }}" == "v1-cloud-run" ]]; then
+            echo "   curl $SERVICE_URL/healthz"
+            echo "   curl $SERVICE_URL/readyz"
+          elif [[ "${{ inputs.module }}" == "v2-firestore" ]]; then
+            echo "   curl $SERVICE_URL/healthz"
+            echo "   curl $SERVICE_URL/readyz"
+            echo "   curl -X POST $SERVICE_URL/todos -H 'Content-Type: application/json' -d '{\"title\":\"Test\",\"completed\":false}'"
+          fi

--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 このリポジトリは、Go言語とGoogle Cloud Platform (GCP) を組み合わせた様々なサンプルコードを管理するモノレポです。
 
+## 主な機能
+
+- 🚀 **Cloud Run** と **Firestore** のサンプル実装
+- 🔐 **GitHub Actions OIDC** によるセキュアなCI/CD
+- 📦 **Go Workspace** を使用したモノレポ管理
+- 🛡️ **Distroless** イメージによる軽量・セキュアなコンテナ
+- ✅ 包括的なテストとLintのCI
+
 ## ディレクトリ構成
 
 各サブディレクトリが独立したGCPサービスのサンプルプロジェクトに対応しています。
@@ -28,6 +36,42 @@ Google Cloud Firestore を利用したサンプルアプリケーションです
 ```bash
 # 例: 全モジュールのテストを実行
 go test ./...
+```
+
+## CI/CD
+
+このリポジトリでは、GitHub ActionsとGoogle CloudのOIDCを利用した安全なCI/CDパイプラインを提供しています。
+
+### ワークフロー
+
+- **Go CI** (`go-ci.yaml`): PR時のLint、テスト、ビルド、セキュリティスキャン
+- **Build and Push to GAR** (`build-push-gar.yaml`): DockerイメージのビルドとArtifact Registryへのプッシュ
+- **Deploy to Cloud Run** (`deploy-cloudrun.yaml`): Cloud Runへのデプロイ
+
+### セットアップ
+
+OIDC認証の設定手順は [docs/OIDC_SETUP.md](./docs/OIDC_SETUP.md) を参照してください。
+
+## 開発
+
+```bash
+# Go 1.24.6をインストール
+go version  # go version go1.24.6 linux/amd64
+
+# 依存関係の取得
+make init
+
+# フォーマット
+make fmt
+
+# Lint
+make lint
+
+# テスト
+make test
+
+# ビルド
+make build
 ```
 
 ## 背景

--- a/docs/OIDC_SETUP.md
+++ b/docs/OIDC_SETUP.md
@@ -1,0 +1,274 @@
+# GitHub Actions OIDC Setup for GCP
+
+このドキュメントでは、GitHub ActionsとGCP間でOIDC (OpenID Connect) を使用した認証を設定する手順を説明します。この設定により、サービスアカウントキーを使わずに安全にGCPリソースへアクセスできます。
+
+## 目次
+
+1. [概要](#概要)
+2. [前提条件](#前提条件)
+3. [GCP側の設定](#gcp側の設定)
+4. [GitHub側の設定](#github側の設定)
+5. [動作確認](#動作確認)
+6. [トラブルシューティング](#トラブルシューティング)
+7. [セキュリティベストプラクティス](#セキュリティベストプラクティス)
+
+## 概要
+
+Workload Identity Federation を使用することで：
+- 🔐 サービスアカウントキーの管理が不要
+- 🚀 短期間の認証トークンを使用してセキュリティを向上
+- 🔄 キーローテーション不要
+- 📊 CloudAudit Logsで詳細な監査が可能
+
+## 前提条件
+
+- GCPプロジェクトが作成済み
+- 必要なAPIが有効化済み：
+  - IAM Service Account Credentials API
+  - Security Token Service API
+- `gcloud` CLIがインストール済み
+- プロジェクトオーナーまたはIAM管理者権限
+
+## GCP側の設定
+
+### 1. 環境変数の設定
+
+```bash
+# プロジェクトIDを設定
+export PROJECT_ID="your-gcp-project-id"
+
+# その他の変数
+export POOL_NAME="github-actions-pool"
+export POOL_DISPLAY_NAME="GitHub Actions Pool"
+export PROVIDER_NAME="github-provider"
+export SA_NAME="github-actions-sa"
+export SA_DISPLAY_NAME="GitHub Actions Service Account"
+export GITHUB_REPO="lancelot89/go-gcp-samples"  # owner/repo形式
+
+# gcloudのデフォルトプロジェクトを設定
+gcloud config set project ${PROJECT_ID}
+```
+
+### 2. Workload Identity Poolの作成
+
+```bash
+gcloud iam workload-identity-pools create ${POOL_NAME} \
+    --location="global" \
+    --display-name="${POOL_DISPLAY_NAME}" \
+    --description="Identity pool for GitHub Actions OIDC"
+```
+
+### 3. Workload Identity Providerの作成
+
+```bash
+gcloud iam workload-identity-pools providers create-oidc ${PROVIDER_NAME} \
+    --location="global" \
+    --workload-identity-pool=${POOL_NAME} \
+    --display-name="GitHub Provider" \
+    --attribute-mapping="google.subject=assertion.sub,attribute.actor=assertion.actor,attribute.repository=assertion.repository,attribute.repository_owner=assertion.repository_owner" \
+    --attribute-condition="assertion.repository == '${GITHUB_REPO}'" \
+    --issuer-uri="https://token.actions.githubusercontent.com"
+```
+
+> **注意**: `--attribute-condition` により、指定したリポジトリからのアクセスのみが許可されます。
+
+### 4. サービスアカウントの作成
+
+```bash
+# サービスアカウントを作成
+gcloud iam service-accounts create ${SA_NAME} \
+    --display-name="${SA_DISPLAY_NAME}" \
+    --description="Service account for GitHub Actions CI/CD"
+
+# 必要な権限を付与
+gcloud projects add-iam-policy-binding ${PROJECT_ID} \
+    --member="serviceAccount:${SA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com" \
+    --role="roles/artifactregistry.writer"
+
+gcloud projects add-iam-policy-binding ${PROJECT_ID} \
+    --member="serviceAccount:${SA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com" \
+    --role="roles/run.developer"
+
+gcloud projects add-iam-policy-binding ${PROJECT_ID} \
+    --member="serviceAccount:${SA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com" \
+    --role="roles/iam.serviceAccountUser"
+```
+
+### 5. Workload Identity PoolとService Accountの紐付け
+
+```bash
+gcloud iam service-accounts add-iam-policy-binding \
+    ${SA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com \
+    --role="roles/iam.workloadIdentityUser" \
+    --member="principalSet://iam.googleapis.com/projects/$(gcloud projects describe ${PROJECT_ID} --format='value(projectNumber)')/locations/global/workloadIdentityPools/${POOL_NAME}/attribute.repository/${GITHUB_REPO}"
+```
+
+### 6. 設定値の確認
+
+```bash
+# Workload Identity Provider のリソース名を取得
+WIF_PROVIDER=$(gcloud iam workload-identity-pools providers describe ${PROVIDER_NAME} \
+    --workload-identity-pool=${POOL_NAME} \
+    --location=global \
+    --format="value(name)")
+
+# Service Account のメールアドレスを取得
+WIF_SERVICE_ACCOUNT="${SA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
+
+echo "========================================"
+echo "GitHub Secrets に設定する値:"
+echo "========================================"
+echo "PROJECT_ID: ${PROJECT_ID}"
+echo "REGION: asia-northeast1"
+echo "WIF_PROVIDER: ${WIF_PROVIDER}"
+echo "WIF_SERVICE_ACCOUNT: ${WIF_SERVICE_ACCOUNT}"
+echo "========================================"
+```
+
+## GitHub側の設定
+
+### 1. リポジトリのSecrets設定
+
+GitHubリポジトリの Settings > Secrets and variables > Actions から以下を追加：
+
+| Secret名 | 値 | 説明 |
+|---------|-----|------|
+| `PROJECT_ID` | 上記で確認した値 | GCPプロジェクトID |
+| `REGION` | `asia-northeast1` | デプロイ先リージョン |
+| `WIF_PROVIDER` | 上記で確認した値 | Workload Identity Provider名 |
+| `WIF_SERVICE_ACCOUNT` | 上記で確認した値 | サービスアカウントメール |
+
+### 2. Artifact Registry リポジトリの作成
+
+```bash
+# Artifact Registry リポジトリを作成（未作成の場合）
+gcloud artifacts repositories create samples \
+    --repository-format=docker \
+    --location=asia-northeast1 \
+    --description="Docker repository for sample applications"
+```
+
+## 動作確認
+
+### 1. GitHub Actions ワークフローの実行
+
+1. GitHubリポジトリのActionsタブを開く
+2. "Build and Push to GAR" ワークフローを選択
+3. "Run workflow" をクリック
+4. モジュールを選択して実行
+
+### 2. ログの確認
+
+正常に認証されていることを確認：
+- "Authenticate to Google Cloud" ステップが成功
+- Docker imageのpushが成功
+
+### 3. GCPコンソールでの確認
+
+Artifact Registryでイメージが作成されていることを確認：
+```bash
+gcloud artifacts docker images list \
+    asia-northeast1-docker.pkg.dev/${PROJECT_ID}/samples
+```
+
+## トラブルシューティング
+
+### 認証エラーが発生する場合
+
+1. **attribute conditionの確認**
+   ```bash
+   # Provider の設定を確認
+   gcloud iam workload-identity-pools providers describe ${PROVIDER_NAME} \
+       --workload-identity-pool=${POOL_NAME} \
+       --location=global
+   ```
+
+2. **IAM bindingの確認**
+   ```bash
+   # Service Account の IAM Policy を確認
+   gcloud iam service-accounts get-iam-policy \
+       ${SA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com
+   ```
+
+3. **Cloud Logging でエラーログを確認**
+   ```bash
+   gcloud logging read "resource.type=iam_service_account" \
+       --limit=10 \
+       --format=json
+   ```
+
+### よくあるエラーと対処法
+
+| エラー | 原因 | 対処法 |
+|-------|------|--------|
+| `Permission 'iam.serviceAccounts.getAccessToken' denied` | Workload Identity User権限がない | IAM bindingを再設定 |
+| `Attribute mapping error` | attribute-mappingが不正 | Provider設定を修正 |
+| `Repository not allowed` | attribute-conditionが不一致 | リポジトリ名を確認 |
+
+## セキュリティベストプラクティス
+
+### 1. 最小権限の原則
+
+サービスアカウントには必要最小限の権限のみを付与：
+```bash
+# 権限を確認
+gcloud projects get-iam-policy ${PROJECT_ID} \
+    --flatten="bindings[].members" \
+    --filter="bindings.members:${SA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com" \
+    --format="table(bindings.role)"
+```
+
+### 2. Attribute Conditionの活用
+
+特定のブランチやタグからのみアクセスを許可：
+```bash
+# mainブランチからのみ許可する例
+--attribute-condition="assertion.repository == '${GITHUB_REPO}' && assertion.ref == 'refs/heads/main'"
+```
+
+### 3. 監査ログの有効化
+
+Cloud Audit Logsで認証アクティビティを監視：
+```bash
+gcloud logging read "protoPayload.serviceName=sts.googleapis.com" \
+    --limit=10 \
+    --format=json
+```
+
+### 4. 定期的な権限レビュー
+
+```bash
+# 未使用のサービスアカウントを特定
+gcloud recommender insights list \
+    --location=global \
+    --insight-type=google.iam.serviceAccount.Insight \
+    --filter="stateInfo.state=ACTIVE"
+```
+
+## リソースのクリーンアップ
+
+不要になった場合の削除手順：
+
+```bash
+# 1. Service Account の削除
+gcloud iam service-accounts delete ${SA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com
+
+# 2. Workload Identity Provider の削除
+gcloud iam workload-identity-pools providers delete ${PROVIDER_NAME} \
+    --workload-identity-pool=${POOL_NAME} \
+    --location=global
+
+# 3. Workload Identity Pool の削除
+gcloud iam workload-identity-pools delete ${POOL_NAME} \
+    --location=global
+
+# 4. Artifact Registry リポジトリの削除（必要な場合）
+gcloud artifacts repositories delete samples \
+    --location=asia-northeast1
+```
+
+## 参考資料
+
+- [Google Cloud - Workload Identity Federation](https://cloud.google.com/iam/docs/workload-identity-federation)
+- [GitHub Docs - About security hardening with OpenID Connect](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect)
+- [google-github-actions/auth](https://github.com/google-github-actions/auth)


### PR DESCRIPTION
## Summary
- GitHub ActionsからGCPへのOIDC認証を実装
- サービスアカウントキー不要でセキュアなCI/CDパイプラインを構築
- Workload Identity Federationの設定ドキュメントを追加

## Changes

### 新規ワークフロー
1. **build-push-gar.yaml**
   - DockerイメージのビルドとArtifact Registryへのプッシュ
   - OIDC認証によるキーレスアクセス
   - マルチプラットフォーム対応（linux/amd64, linux/arm64）
   - GitHub Actions キャッシュによる高速化

2. **deploy-cloudrun.yaml**
   - Cloud Runへのデプロイメント
   - 手動実行用（workflow_dispatch）
   - 環境変数と認証設定のカスタマイズ可能

### ドキュメント
- **docs/OIDC_SETUP.md**: Workload Identity Federationの詳細な設定手順
  - GCP側の設定（Pool, Provider, Service Account）
  - GitHub側の設定（Secrets）
  - トラブルシューティングガイド
  - セキュリティベストプラクティス

### README更新
- CI/CD機能の説明を追加
- OIDCセットアップへのリンクを追加

## Security Benefits
- 🔐 サービスアカウントキーの管理不要
- 🚀 短期間の認証トークンによるセキュリティ向上
- 🔄 キーローテーション不要
- 📊 CloudAudit Logsによる詳細な監査

## Setup Required
設定手順は `docs/OIDC_SETUP.md` を参照してください。

## Test plan
- [ ] GitHub Secretsの設定
- [ ] Workload Identity Federationの設定
- [ ] build-push-garワークフローの実行確認
- [ ] deploy-cloudrunワークフローの実行確認

## Related
Closes #16

🤖 Generated with [Claude Code](https://claude.ai/code)